### PR TITLE
Fix junit report xml declaration attribute order

### DIFF
--- a/lib/junit_report.tpl
+++ b/lib/junit_report.tpl
@@ -1,4 +1,4 @@
-<?xml encoding="UTF-8" version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <testsuites failures="{{stats.failures}}" name="">
 	{{#files}}
 		<testsuite failures="{{stats.failures}}" name="{{file}}">


### PR DESCRIPTION
Hey @natecavanaugh,

We found this issue when updating the `sfm` tool in the CI servers. 

It turns out that (as per http://www.w3.org/TR/REC-xml/#NT-XMLDecl), the xml declaration attributes are order sensitive, so the `xunit` xml parser now fails to consume the generated xmls.

Thanks!

/cc @mdelapenya @cgoncas