### PR TITLE
Use CDATA section on failure messages to properly allow html entities

### DIFF
--- a/lib/junit_report.tpl
+++ b/lib/junit_report.tpl
@@ -5,12 +5,12 @@
 			{{#errors}}
 				<testcase name="{{testName}}">
 					{{#failure}}
-						<failure message="{{violationType}}" type="failure">
+						<failure message="{{violationType}}" type="failure"><![CDATA[
 							{{~#stack~}}
 								{{line}}: {{{msg}}}{{#and @root.showLintIds ruleId}} ({{ruleId}}){{/and}}{{#unless @last}}
 {{/unless}}
 							{{~/stack~}}
-						</failure>
+						]]></failure>
 					{{/failure}}
 				</testcase>
 			{{/errors}}

--- a/lib/junit_report.tpl
+++ b/lib/junit_report.tpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites failures="{{stats.failures}}" name="">
 	{{#files}}
-		<testsuite failures="{{stats.failures}}" name="{{file}}">
+		<testsuite failures="{{stats.failures}}" name="{{file}}" tests="1">
 			{{#errors}}
 				<testcase name="{{testName}}">
 					{{#failure}}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mocha": "^2.1.0",
     "mocha-lcov-reporter": "0.0.2",
     "run-sequence": "^1.0.2",
-    "sinon": "^1.12.2"
+    "sinon": "^1.12.2",
+    "xsd-schema-validator": "^0.3.0"
   }
 }

--- a/test/fixture/junit-4.xsd
+++ b/test/fixture/junit-4.xsd
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped" type="xs:string"/>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="assertions" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="classname" type="xs:string" use="optional"/>
+            <xs:attribute name="status" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="hostname" type="xs:string" use="optional"/>
+            <xs:attribute name="id" type="xs:string" use="optional"/>
+            <xs:attribute name="package" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+
+</xs:schema>

--- a/test/fixture/result.xml
+++ b/test/fixture/result.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites failures="7" name="">
-		<testsuite failures="5" name="foo.js">
+		<testsuite failures="5" name="foo.js" tests="1">
 				<testcase name="undefined">
 						<failure message="" type="failure">Line 1: Content is not valid
 Line 4: Content is not valid</failure>
@@ -13,12 +13,12 @@ Line 5: Something is not valid</failure>
 						<failure message="" type="failure">Line 3: Content is not valid</failure>
 				</testcase>
 		</testsuite>
-		<testsuite failures="1" name="bar.html">
+		<testsuite failures="1" name="bar.html" tests="1">
 				<testcase name="warning">
 						<failure message="" type="failure">Line 10: Content is not valid</failure>
 				</testcase>
 		</testsuite>
-		<testsuite failures="1" name="baz.css">
+		<testsuite failures="1" name="baz.css" tests="1">
 				<testcase name="error">
 						<failure message="" type="failure">Line 1: Content is not valid</failure>
 				</testcase>

--- a/test/fixture/result.xml
+++ b/test/fixture/result.xml
@@ -2,25 +2,25 @@
 <testsuites failures="7" name="">
 		<testsuite failures="5" name="foo.js" tests="1">
 				<testcase name="undefined">
-						<failure message="" type="failure">Line 1: Content is not valid
-Line 4: Content is not valid</failure>
+						<failure message="" type="failure"><![CDATA[Line 1: Content is not valid
+Line 4: Content is not valid]]></failure>
 				</testcase>
 				<testcase name="error">
-						<failure message="" type="failure">Line 2: Content is not valid
-Line 5: Something is not valid</failure>
+						<failure message="" type="failure"><![CDATA[Line 2: Content is not valid
+Line 5: Something is not valid]]></failure>
 				</testcase>
 				<testcase name="warning">
-						<failure message="" type="failure">Line 3: Content is not valid</failure>
+						<failure message="" type="failure"><![CDATA[Line 3: Content is not valid]]></failure>
 				</testcase>
 		</testsuite>
 		<testsuite failures="1" name="bar.html" tests="1">
 				<testcase name="warning">
-						<failure message="" type="failure">Line 10: Content is not valid</failure>
+						<failure message="" type="failure"><![CDATA[Line 10: Content is not valid]]></failure>
 				</testcase>
 		</testsuite>
 		<testsuite failures="1" name="baz.css" tests="1">
 				<testcase name="error">
-						<failure message="" type="failure">Line 1: Content is not valid</failure>
+						<failure message="" type="failure"><![CDATA[Line 1: Content is not valid]]></failure>
 				</testcase>
 		</testsuite>
 </testsuites>

--- a/test/junit.js
+++ b/test/junit.js
@@ -86,6 +86,9 @@ describe(
 				var logger = new Logger.Logger();
 
 				logger.log(1, 'Content is not valid', 'foo.js');
+				logger.log(38, 'Missing space between selector and bracket: &.no-title .asset-user-actions{', 'xmlentity.css', 'error');
+				logger.log(39, '<fooo', 'xmlentity.css', 'error');
+				logger.log(141, 'Sort attribute values: javascript:�0�removeGroup(', 'unicode.css', 'error');
 
 				sandbox.stub(
 					fs,

--- a/test/junit.js
+++ b/test/junit.js
@@ -2,6 +2,7 @@ var chai = require('chai');
 var fs = require('fs');
 var path = require('path');
 var sinon = require('sinon');
+var xsd = require('xsd-schema-validator');
 
 var junit = require('../lib/junit');
 var Logger = require('../lib/logger');
@@ -76,6 +77,50 @@ describe(
 				assert.isTrue(cb.called, 'cb should have been executed');
 
 				assert.equal(cb.args[0][1], fs.readFileSync(path.join(__dirname, 'fixture', 'result.xml'), 'utf-8'), 'The result should match what we expect');
+			}
+		);
+
+		it (
+			'should generate a valid JUnit report',
+			function(done) {
+				var logger = new Logger.Logger();
+
+				logger.log(1, 'Content is not valid', 'foo.js');
+
+				sandbox.stub(
+					fs,
+					'readFile',
+					function(path, encoding, callback) {
+						if (path.indexOf('junit_report.tpl') > -1) {
+							return callback(null, fs.readFileSync(path, encoding));
+						}
+
+						callback(null, '');
+					}
+				);
+
+				sandbox.stub(
+					fs,
+					'writeFile',
+					function(path, content, callback) {
+						callback(null, content);
+					}
+				);
+
+				var cb = sandbox.spy();
+
+				var reporter = new junit(
+					{
+						logger: logger
+					}
+				);
+
+				reporter.generate(cb);
+
+				xsd.validateXML(cb.args[0][1], path.join(__dirname, 'fixture', 'junit-4.xsd'), function(err, result) {
+					assert.isTrue(result.valid, err);
+					done();
+				});
 			}
 		);
 


### PR DESCRIPTION
Hey Nate,

As we discussed last week, I've added some tests to validate the junit output against the schema (turns out we weren't missing that much), and to fix and test for invalid characters inside the failure messages.

Thanks!